### PR TITLE
[bugfix] Exception when context is't Activity

### DIFF
--- a/NasSDK/libnebulas/src/main/java/io/nebulas/action/ContractAction.java
+++ b/NasSDK/libnebulas/src/main/java/io/nebulas/action/ContractAction.java
@@ -25,6 +25,7 @@ public class ContractAction {
         }
         try {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(intent);
         } catch (Exception e) {
             handleException(context);
@@ -33,6 +34,7 @@ public class ContractAction {
 
     private static void handleException(Context context){
         Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         Toast.makeText(context, "没安装Nebulas智能数字钱包，正在前往官网下载...", Toast.LENGTH_LONG).show();
         intent.setData(Uri.parse(String.format(Constants.NAS_NANO_DOWNLOAD_URL)));
         if (intent.resolveActivity(context.getPackageManager()) != null) {


### PR DESCRIPTION
When call ContractAction.start(), if context is not activity, the sdk think wallet is not install, then call context.startActivity(intent), throw exception.

android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
        at android.app.ContextImpl.startActivity(ContextImpl.java:1042)
        at android.app.ContextImpl.startActivity(ContextImpl.java:1029)
        at android.content.ContextWrapper.startActivity(ContextWrapper.java:311)
        at android.content.ContextWrapper.startActivity(ContextWrapper.java:311)
        at io.nebulas.action.ContractAction.handleException(ContractAction.java:41)
        at io.nebulas.action.ContractAction.start(ContractAction.java:31)
        at io.nebulas.api.SmartContracts.call(SmartContracts.java:119)